### PR TITLE
configure Glup & `npm version` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bower_components
+node_modules
+npm-debug.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+We welcome and truly appreciate contribution in all forms - issues, pull requests, questions, or fancy examples of apps/elements build on to of your elements.
+
+## Filing bugs
+
+Our team heavily uses Github for all of our software management. We use Github issues to track all bugs and features.
+
+If you find an issue, please do file it on the repository.
+
+We love examples for addressing issues - issues with a Plunkr, [jsFiddle](http://jsfiddle.net), or [jsBin](http://jsbin.com) will be much easier for us to work on quickly. You can start with [this jsbin](http://jsbin.com/capequ/edit?html,output) which sets up the basics to demonstrate a Juicy element.
+
+Occasionally we'll close issues if they appear stale or are too vague - please don't take this personally! Please feel free to re-open issues we've closed if there's something we've missed and they still need to be addressed.
+
+## Developing the element
+
+If you would like to start to fiddle with element's code, here is the flow we use.
+
+- Make a local clone of this repo: `git clone git@github.com:Juicy/juicy-filedrop.git`
+
+In order to develop it locally we suggest to use [polyserve](https://npmjs.com/polyserve) tool to handle bower paths gently.
+
+0. Go to the repo's directory: `cd juicy-filedrop`
+1. Install [bower](http://bower.io/) & [polyserve](https://npmjs.com/polyserve): `$ npm install -g bower polyserve`
+2. Install local dependencies: `$ bower install`
+3. Start development server `$ polyserve -p 8000`
+4. Open the demo/preview: [http://localhost:8000/components/juicy-filedrop/](http://localhost:8000/components/juicy-filedrop/)
+
+## Contributing Pull Requests
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -m 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Open corresponding issue if needed
+6. Submit a pull request :D
+
+### Styleguide
+
+`.jscs.json`/`.jscsrc`/`package.json` to be linked
+
+### How to release a package
+
+1. Install [Node.js](https://nodejs.org/).
+2. Run `npm install` to install all dependencies.
+3. Run `npm version ...` to bump the version. You can use `npm version 1.0.0`, `npm version major`, `npm version minor`, `npm version patch` or whatever else [npm version](https://docs.npmjs.com/cli/version) supports.
+4. Run `git push && git push --tags` to push the changes made by `npm version`.

--- a/README.md
+++ b/README.md
@@ -61,13 +61,7 @@ Event        | Description
 `openFile`   | Opens file prompt
 
 
-## Contributing
-
-1. Fork it!
-2. Create your feature branch: `git checkout -b my-new-feature`
-3. Commit your changes: `git commit -m 'Add some feature'`
-4. Push to the branch: `git push origin my-new-feature`
-5. Submit a pull request :D
+## [Contributing and Development](CONTRIBUTING.md)
 
 ## History
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "juicy-filedrop",
-  "version": "1.0.3",
   "homepage": "https://github.com/Juicy/juicy-filedrop",
   "authors": [
     "andwah <anders.wahlgren@societyobjects.com>",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,10 @@
 var gulp = require('gulp');
 var replace = require('gulp-replace');
-var pjson = require('./package.json');
+var packageJson = require('./package.json');
+var bowerJson = require('./bower.json');
 
 gulp.task('propagate-version', function() {
-  gulp.src(['./bower.json'])
-    .pipe(replace(/"version": "\d+\.\d+\.\d+"/, '"version": "' + pjson.version + '"'))
-    .pipe(gulp.dest('./'));
-
-  gulp.src(['./juicy-filedrop.html'])
-    .pipe(replace(/version: \d+\.\d+\.\d+/, 'version: ' + pjson.version))
+  gulp.src(['./bower.json', './juicy-filedrop.html'])
+    .pipe(replace(bowerJson.version, packageJson.version))
     .pipe(gulp.dest('./'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,17 +1,10 @@
 var gulp = require('gulp');
 var replace = require('gulp-replace');
-var spawn = require('child_process').spawnSync;
 
 gulp.task('propagate-version', function() {
   var next = require('./package.json');
 
-  //current working directory already have a new version number after `npm version`
-  //old version number is available in git history, let's take it
-  var git = spawn('git', ['show', 'HEAD:./package.json']);
-  var out = git.stdout.toString()
-  var old = JSON.parse(out);
-
   gulp.src(['./juicy-filedrop.html'])
-    .pipe(replace(old.version, next.version))
+    .pipe(replace(/version: (.*)/, 'version: ' + next.version))
     .pipe(gulp.dest('./'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,10 +1,17 @@
 var gulp = require('gulp');
 var replace = require('gulp-replace');
-var packageJson = require('./package.json');
-var bowerJson = require('./bower.json');
+var spawn = require('child_process').spawnSync;
 
 gulp.task('propagate-version', function() {
-  gulp.src(['./bower.json', './juicy-filedrop.html'])
-    .pipe(replace(bowerJson.version, packageJson.version))
+  var next = require('./package.json');
+
+  //current working directory already have a new version number after `npm version`
+  //old version number is available in git history, let's take it
+  var git = spawn('git', ['show', 'HEAD:./package.json']);
+  var out = git.stdout.toString()
+  var old = JSON.parse(out);
+
+  gulp.src(['./juicy-filedrop.html'])
+    .pipe(replace(old.version, next.version))
     .pipe(gulp.dest('./'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,13 @@
+var gulp = require('gulp');
+var replace = require('gulp-replace');
+var pjson = require('./package.json');
+
+gulp.task('propagate-version', function() {
+  gulp.src(['./bower.json'])
+    .pipe(replace(/"version": "\d+\.\d+\.\d+"/, '"version": "' + pjson.version + '"'))
+    .pipe(gulp.dest('./'));
+
+  gulp.src(['./juicy-filedrop.html'])
+    .pipe(replace(/version: \d+\.\d+\.\d+/, 'version: ' + pjson.version))
+    .pipe(gulp.dest('./'));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,6 @@ gulp.task('propagate-version', function() {
   var next = require('./package.json');
 
   gulp.src(['./juicy-filedrop.html'])
-    .pipe(replace(/version: (.*)/, 'version: ' + next.version))
+    .pipe(replace(/version:\s*(.+)/, 'version: ' + next.version))
     .pipe(gulp.dest('./'));
 });

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "juicy-filedrop",
+  "version": "1.0.3",
+  "description": "Polymer Element with file drop panel",
+  "main": "juicy-filedrop.html",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Juicy/juicy-filedrop.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Juicy/juicy-filedrop/issues"
+  },
+  "homepage": "https://github.com/Juicy/juicy-filedrop#readme"
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "version": "gulp propagate-version && git add ./bower.json ./juicy-filedrop.html"
+    "version": "gulp propagate-version && git add ./juicy-filedrop.html"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "version": "gulp propagate-version && git add ./bower.json ./juicy-filedrop.html"
   },
   "repository": {
     "type": "git",
@@ -18,5 +19,9 @@
   "bugs": {
     "url": "https://github.com/Juicy/juicy-filedrop/issues"
   },
-  "homepage": "https://github.com/Juicy/juicy-filedrop#readme"
+  "homepage": "https://github.com/Juicy/juicy-filedrop#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-replace": "^0.5.4"
+  }
 }


### PR DESCRIPTION
I experimented with using NPM & Gulp instead of Grunt for bumping a version.

I could not use pure NPM, because it is too hard to fit replacing of versions in `bower.json` and `juicy-filedrop.html` in a single-line NPM script. Even harder to make that work cross-platform.
